### PR TITLE
Get rid of race condition in multithreaded environment

### DIFF
--- a/examples/authenticode_dumper.c
+++ b/examples/authenticode_dumper.c
@@ -157,7 +157,8 @@ int main(int argc, char **argv)
 
     fread(data, 1, fsize, fp);
     fclose(fp);
-
+    /* initialize all global openssl objects */
+    initialize_authenticode_parser();
     AuthenticodeArray *auth = parse_authenticode(data, fsize);
     if (!auth) {
         printf("Couldn't parse any signatures.\n");

--- a/include/authenticode-parser/authenticode.h
+++ b/include/authenticode-parser/authenticode.h
@@ -156,6 +156,13 @@ typedef struct {
 } AuthenticodeArray;
 
 /**
+ * @brief Initializes all globals OpenSSl objects we need for parsing, this is not thread-safe and
+ *        needs to be called only once, before any multithreading environment
+ *        https://github.com/openssl/openssl/issues/13524
+ */
+void initialize_authenticode_parser();
+
+/**
  * @brief Constructs AuthenticodeArray from PE file data. Authenticode can
  *        contains nested Authenticode signatures as its unsigned attribute,
  *        which can also contain nested signatures. For this reason the function returns

--- a/src/authenticode.c
+++ b/src/authenticode.c
@@ -273,8 +273,9 @@ static bool authenticode_verify(PKCS7* p7, PKCS7_SIGNER_INFO* si, X509* signCert
     return isValid;
 }
 
-/* Creates all the Authenticode objects so we can parse them with OpenSSL */
-static void initialize_openssl()
+/* Creates all the Authenticode objects so we can parse them with OpenSSL, is not thread-safe, needs
+ * to be called once before any multi-threading environmentt - https://github.com/openssl/openssl/issues/13524 */
+void initialize_authenticode_parser()
 {
     OBJ_create("1.3.6.1.4.1.311.2.1.12", "spcSpOpusInfo", "SPC_SP_OPUS_INFO_OBJID");
     OBJ_create("1.3.6.1.4.1.311.3.3.1", "spcMsCountersignature", "SPC_MICROSOFT_COUNTERSIGNATURE");
@@ -288,9 +289,6 @@ AuthenticodeArray* authenticode_new(const uint8_t* data, long len)
 {
     if (!data || len == 0)
         return NULL;
-
-    /* We need to initialize all the custom objects for further parsing */
-    initialize_openssl();
 
     AuthenticodeArray* result = (AuthenticodeArray*)calloc(1, sizeof(*result));
     if (!result)

--- a/tests/integration/test.cpp
+++ b/tests/integration/test.cpp
@@ -50,6 +50,8 @@ class SignatureTest : public testing::Test
         BIO_free_all(bio);
         OPENSSL_free(name);
         OPENSSL_free(header);
+
+        initialize_authenticode_parser();
     }
 
     void TearDown() override { OPENSSL_free(data); }
@@ -827,6 +829,8 @@ TEST_F(SignatureTest, ThirdSignatureContent)
 
 TEST(PefileTest, ResultOverview)
 {
+    initialize_authenticode_parser();
+
     AuthenticodeArray *auth = parse_authenticode(PE_FILE_1, PE_FILE_1_LEN);
     ASSERT_NE(auth, nullptr);
 


### PR DESCRIPTION
Due to the way OBJ_create works in openssl 1.1.1 https://github.com/openssl/openssl/issues/13524 we can get to a double-free situation in a multithreaded environment. This requires the library user to invoke `initialize_authenticode_parser()` himself before any multithreaded environment as the library needs the global openssl objects initialized to work.