### PR TITLE
Fixed ByteArray allocation with 0 length

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -58,6 +58,12 @@ end:
 
 int byte_array_init(ByteArray* arr, const uint8_t* data, int len)
 {
+    if (len == 0) {
+        arr->data = NULL;
+        arr->len = 0;
+        return 0;
+    }
+
     arr->data = (uint8_t*)malloc(len);
     if (!arr->data)
         return -1;


### PR DESCRIPTION
It's unnecessary to allocate anything when the size of the buffer is declared to be 0 bytes. It might lead to issues where condition over data pointer can lead to invalid memory access.