### PR TITLE
replace time_t with int64_t

### DIFF
--- a/include/authenticode-parser/authenticode.h
+++ b/include/authenticode-parser/authenticode.h
@@ -106,8 +106,8 @@ typedef struct {
     char* key_alg;            /* Name of the key algorithm */
     char* sig_alg;            /* Name of the signature algorithm */
     char* sig_alg_oid;        /* OID of the signature algorithm */
-    time_t not_before;        /* NotBefore validity */
-    time_t not_after;         /* NotAfter validity */
+    int64_t not_before;       /* NotBefore validity */
+    int64_t not_after;        /* NotAfter validity */
     char* key;                /* PEM encoded public key */
     Attributes issuer_attrs;  /* Parsed X509 Attributes of Issuer */
     Attributes subject_attrs; /* Parsed X509 Attributes of Subject */
@@ -120,7 +120,7 @@ typedef struct {
 
 typedef struct {
     int verify_flags;        /* COUNTERISGNATURE_VFY_ flag */
-    time_t sign_time;        /* Signing time of the timestamp countersignature */
+    int64_t sign_time;       /* Signing time of the timestamp countersignature */
     char* digest_alg;        /* Name of the digest algorithm used */
     ByteArray digest;        /* Stored message digest */
     CertificateArray* chain; /* Certificate chain of the signer */

--- a/src/certificate.c
+++ b/src/certificate.c
@@ -308,8 +308,8 @@ Certificate* certificate_new(X509* x509)
 
     result->version = X509_get_version(x509);
     result->serial = integer_to_serial(X509_get_serialNumber(x509));
-    result->not_after = ASN1_TIME_to_time_t(X509_get0_notAfter(x509));
-    result->not_before = ASN1_TIME_to_time_t(X509_get0_notBefore(x509));
+    result->not_after = ASN1_TIME_to_int64_t(X509_get0_notAfter(x509));
+    result->not_before = ASN1_TIME_to_int64_t(X509_get0_notBefore(x509));
     int sig_nid = X509_get_signature_nid(x509);
     result->sig_alg = strdup(OBJ_nid2ln(sig_nid));
 

--- a/src/countersignature.c
+++ b/src/countersignature.c
@@ -58,7 +58,7 @@ Countersignature* pkcs9_countersig_new(
         goto end;
     }
 
-    result->sign_time = ASN1_TIME_to_time_t(sign_time->value.utctime);
+    result->sign_time = ASN1_TIME_to_int64_t(sign_time->value.utctime);
 
     X509* signCert = X509_find_by_issuer_and_serial(
         certs, si->issuer_and_serial->issuer, si->issuer_and_serial->serial);
@@ -205,7 +205,7 @@ Countersignature* ms_countersig_new(const uint8_t* data, long size, ASN1_STRING*
         return result;
     }
 
-    result->sign_time = ASN1_TIME_to_time_t(rawTime);
+    result->sign_time = ASN1_TIME_to_int64_t(rawTime);
 
     STACK_OF(X509)* sigs = PKCS7_get0_signers(p7, p7->d.sign->cert, 0);
     X509* signCert = sk_X509_value(sigs, 0);

--- a/src/helper.c
+++ b/src/helper.c
@@ -73,7 +73,7 @@ int byte_array_init(ByteArray* arr, const uint8_t* data, int len)
     return 0;
 }
 
-time_t ASN1_TIME_to_time_t(const ASN1_TIME* time)
+int64_t ASN1_TIME_to_int64_t(const ASN1_TIME* time)
 {
     struct tm t = {0};
     if (!time)

--- a/src/helper.h
+++ b/src/helper.h
@@ -59,7 +59,7 @@ int calculate_digest(const EVP_MD* md, const uint8_t* data, size_t len, uint8_t*
 /* Copies data of length len into already existing arr */
 int byte_array_init(ByteArray* arr, const uint8_t* data, int len);
 /* Converts ASN1_TIME string time into a unix timestamp */
-time_t ASN1_TIME_to_time_t(const ASN1_TIME* time);
+int64_t ASN1_TIME_to_int64_t(const ASN1_TIME* time);
 
 #ifdef __cplusplus
 }

--- a/tests/unit/helper.cpp
+++ b/tests/unit/helper.cpp
@@ -41,31 +41,31 @@ TEST(HelperModule, byte_array_init_2)
     free(array.data);
 }
 
-TEST(HelperModule, asn1_get_time_t_0)
+TEST(HelperModule, asn1_time_get_int64_t_0)
 {
     auto asn1time = ASN1_TIME_new();
     ASN1_TIME_set(asn1time, 1527779085);
-    time_t res = ASN1_TIME_to_time_t(asn1time);
+    int64_t res = ASN1_TIME_to_int64_t(asn1time);
     EXPECT_EQ(res, 1527779085);
     ASN1_TIME_free(asn1time);
 }
 
-TEST(HelperModule, asn1_get_time_t_1)
+TEST(HelperModule, asn1_time_get_int64_t_1)
 {
     auto asn1time = ASN1_TIME_new();
     int succ = ASN1_TIME_set_string(asn1time, "211014101955Z");
     EXPECT_TRUE(succ);
-    time_t res = ASN1_TIME_to_time_t(asn1time);
+    int64_t res = ASN1_TIME_to_int64_t(asn1time);
     EXPECT_EQ(res, 1634206795);
     ASN1_TIME_free(asn1time);
 }
 
-TEST(HelperModule, asn1_get_time_t_2)
+TEST(HelperModule, asn1_time_get_int64_t_2)
 {
     auto asn1time = ASN1_TIME_new();
     int succ = ASN1_TIME_set_string_X509(asn1time, "19700102212340Z");
     EXPECT_TRUE(succ);
-    time_t res = ASN1_TIME_to_time_t(asn1time);
+    int64_t res = ASN1_TIME_to_int64_t(asn1time);
     EXPECT_EQ(res, 163420);
     ASN1_TIME_free(asn1time);
 }


### PR DESCRIPTION
I am working on rust bindings on top of this library, which are working fine. However, i would like to be able to provide the bindings without having to auto-gen them from the header files (so that the build time are kept low), but there is one issue: the objects uses the `time_t` type.

Since time_t is a platform dependent type, the size and layouts of the returned structs depend on its definition, which means I cannot provide a rust equivalent for those structs, and have to generate those equivalents on the fly for the target arch.

Replacing it with int64_t makes its size properly defined and solves this issue. Some 32-bits platform have `time_t = in32_t`, and other have `time_t = int64_t`, but no platform I know has `time_t > int64_t`, so AFAICT this change is safe to do.