### PR TITLE
feat: use int32_t for len of data in authenticode_new

### DIFF
--- a/include/authenticode-parser/authenticode.h
+++ b/include/authenticode-parser/authenticode.h
@@ -190,7 +190,7 @@ AuthenticodeArray* parse_authenticode(const uint8_t* pe_data, uint64_t pe_len);
  * @param len
  * @return AuthenticodeArray*
  */
-AuthenticodeArray* authenticode_new(const uint8_t* data, long len);
+AuthenticodeArray* authenticode_new(const uint8_t* data, int32_t len);
 
 /**
  * @brief Deallocates AuthenticodeArray and all it's allocated members

--- a/src/authenticode.c
+++ b/src/authenticode.c
@@ -285,9 +285,9 @@ void initialize_authenticode_parser()
 
 /* Return array of Authenticode signatures stored in the data, there can be multiple
  * of signatures as Authenticode signatures are often nested through unauth attributes */
-AuthenticodeArray* authenticode_new(const uint8_t* data, long len)
+AuthenticodeArray* authenticode_new(const uint8_t* data, int32_t len)
 {
-    if (!data || len == 0)
+    if (!data || len <= 0)
         return NULL;
 
     AuthenticodeArray* result = (AuthenticodeArray*)calloc(1, sizeof(*result));


### PR DESCRIPTION
As is done for the other entrypoint of the library `parse_authenticode`, use a signed large type for the length of the payload.