### PR TITLE
Adding more checks for pointers to the code

### DIFF
--- a/examples/authenticode_dumper.c
+++ b/examples/authenticode_dumper.c
@@ -31,6 +31,8 @@ void print_bytes(const ByteArray *bytes)
             printf("%02x", bytes->data[i]);
         }
         puts("");
+    } else {
+        puts("(null)");
     }
 }
 
@@ -68,14 +70,15 @@ void print_authenticode(Authenticode *auth)
     print_bytes(&auth->file_digest);
     printf("%sDigest Algorithm  : %s\n", indent, auth->digest_alg);
     printf("%sVerify flags      : %d\n", indent, auth->verify_flags);
-    printf("%sCertificate count : %ld\n", indent, auth->certs->count);
-    printf("%sCertificates: \n", indent);
     if (auth->signer->program_name) {
         printf("%sProgram name      : %s\n", indent, auth->signer->program_name);
     }
     printf("\n");
 
     if (auth->certs) {
+        printf("%sCertificate count : %ld\n", indent, auth->certs->count);
+        printf("%sCertificates: \n\n", indent);
+
         for (size_t i = 0; i < auth->certs->count; ++i) {
             char *indent = "        ";
 

--- a/src/authenticode.c
+++ b/src/authenticode.c
@@ -320,7 +320,7 @@ AuthenticodeArray* authenticode_new(const uint8_t* data, int32_t len)
     }
 
     /* We expect SignedData type of PKCS7 */
-    if (!PKCS7_type_is_signed(p7)) {
+    if (!PKCS7_type_is_signed(p7) || !p7->d.sign) {
         auth->verify_flags = AUTHENTICODE_VFY_WRONG_PKCS7_TYPE;
         goto end;
     }

--- a/src/countersignature.c
+++ b/src/countersignature.c
@@ -260,7 +260,7 @@ TS_TST_INFO* IMPL_FUNC_NAME(get_ts_tst_info, cms)(CountersignatureImpl* impl)
     assert(impl->type == CS_IMPL_CMS);
 
     const ASN1_OBJECT* content_type = CMS_get0_eContentType(impl->cms);
-    if (OBJ_obj2nid(content_type) != NID_id_smime_ct_TSTInfo) {
+    if (!content_type || OBJ_obj2nid(content_type) != NID_id_smime_ct_TSTInfo) {
         return NULL;
     }
 
@@ -450,7 +450,7 @@ CountersignatureImpl* ms_countersig_impl_new(const uint8_t* data, long size)
 {
     const uint8_t* d = data;
     PKCS7* p7 = d2i_PKCS7(NULL, &d, size);
-    if (p7) {
+    if (p7 && PKCS7_type_is_signed(p7) && p7->d.sign) {
         CountersignatureImpl* result =
             (CountersignatureImpl*)calloc(1, sizeof(CountersignatureImpl));
         result->type = CS_IMPL_PKCS7;


### PR DESCRIPTION
Should make the code more robust against PKCS7 corrupted structures.

Also making example dumper more robust with not crashing when no certs are parsed and to print NULL values as "(null)" and not a blank line without any line delimiter.