### PR TITLE
Fix invalid pointer dereference in `extract_ms_counter_certs`

### DIFF
--- a/src/authenticode.c
+++ b/src/authenticode.c
@@ -197,6 +197,12 @@ static void extract_ms_counter_certs(const uint8_t* data, int len, CertificateAr
     if (!p7)
         return;
 
+    /* We expect SignedData type of PKCS7 */
+    if (!PKCS7_type_is_signed(p7) || !p7->d.sign) {
+        PKCS7_free(p7);
+        return;
+    }
+
     STACK_OF(X509)* certs = p7->d.sign->cert;
     CertificateArray* certArr = certificate_array_new(sk_X509_num(certs));
     if (!certArr) {


### PR DESCRIPTION
I'm not quite sure if this fix is correct. It certainly prevents the SIGSEGV with file `e9b3cadbd8fdb7a26a7130e7b40d4a99632fa6f767b0339385e5786d66015cfb`, but I don't know if it is logically correct.

Closes #19