### PR TITLE
Append MS countersignature certificates to the Authenticode signature certs

### DIFF
--- a/examples/authenticode_dumper.c
+++ b/examples/authenticode_dumper.c
@@ -173,7 +173,6 @@ int main(int argc, char **argv)
     }
 
     printf("Signature count: %lu\n", auth->count);
-    printf("Signatures: %lu\n", auth->count);
 
     for (size_t i = 0; i < auth->count; ++i)
         print_authenticode(auth->signatures[i]);

--- a/include/authenticode-parser/authenticode.h
+++ b/include/authenticode-parser/authenticode.h
@@ -124,6 +124,8 @@ typedef struct {
     char* digest_alg;        /* Name of the digest algorithm used */
     ByteArray digest;        /* Stored message digest */
     CertificateArray* chain; /* Certificate chain of the signer */
+    CertificateArray* certs; /* All certs stored inside Countersignature, this can be superset
+                                of chain in case of non PKCS9 countersignature*/
 } Countersignature;
 
 typedef struct {

--- a/src/authenticode.c
+++ b/src/authenticode.c
@@ -203,8 +203,7 @@ static void parse_ms_countersig(PKCS7* p7, Authenticode* auth)
         countersignature_array_insert(auth->countersigs, csig);
         /* Because MS TimeStamp countersignature has it's own SET of certificates
          * extract it back into parent signature for consistency with PKCS9 */
-        if (csig->certs && csig->certs->count > 0)
-            certificate_array_append(auth->certs, csig->certs);
+        certificate_array_append(auth->certs, csig->certs);
     }
 }
 

--- a/src/certificate.c
+++ b/src/certificate.c
@@ -351,6 +351,23 @@ void attributes_copy(Attributes* dst, Attributes* src)
     byte_array_init(&dst->emailAddress, src->emailAddress.data, src->emailAddress.len);
 }
 
+/* Parses X509* certs into internal representation and inserts into CertificateArray
+ * Array is assumed to have enough space to hold all certificates storted in the STACK */
+void parse_x509_certificates(const STACK_OF(X509) * certs, CertificateArray* result)
+{
+    int certCount = sk_X509_num(certs);
+    int i = 0;
+    for (; i < certCount; ++i) {
+        Certificate* cert = certificate_new(sk_X509_value(certs, i));
+        if (!cert)
+            break;
+
+        /* Write to the result */
+        result->certs[i] = cert;
+    }
+    result->count = i;
+}
+
 /* Creates deep copy of a certificate */
 Certificate* certificate_copy(Certificate* cert)
 {

--- a/src/certificate.c
+++ b/src/certificate.c
@@ -400,6 +400,12 @@ Certificate* certificate_copy(Certificate* cert)
  * else 1. If error occurs, arguments are unchanged */
 int certificate_array_move(CertificateArray* dst, CertificateArray* src)
 {
+    if (!dst || !src)
+        return 1;
+
+    if (!src->certs || !src->count)
+        return 0;
+
     size_t newCount = dst->count + src->count;
 
     Certificate** tmp = (Certificate**)realloc(dst->certs, newCount * sizeof(Certificate*));
@@ -424,6 +430,12 @@ int certificate_array_move(CertificateArray* dst, CertificateArray* src)
  * else 1. If error occurs, arguments are unchanged */
 int certificate_array_append(CertificateArray* dst, CertificateArray* src)
 {
+    if (!dst || !src)
+        return 1;
+
+    if (!src->certs || !src->count)
+        return 0;
+
     size_t newCount = dst->count + src->count;
 
     Certificate** tmp = (Certificate**)realloc(dst->certs, newCount * sizeof(Certificate*));

--- a/src/certificate.h
+++ b/src/certificate.h
@@ -31,10 +31,12 @@ extern "C" {
 #endif
 
 Certificate* certificate_new(X509* x509);
+Certificate* certificate_copy(Certificate* cert);
 void certificate_free(Certificate* cert);
 
 CertificateArray* parse_signer_chain(X509* signer_cert, STACK_OF(X509) * certs);
 int certificate_array_move(CertificateArray* dst, CertificateArray* src);
+int certificate_array_append(CertificateArray* dst, CertificateArray* src);
 CertificateArray* certificate_array_new(int certCount);
 void certificate_array_free(CertificateArray* arr);
 

--- a/src/certificate.h
+++ b/src/certificate.h
@@ -34,6 +34,8 @@ Certificate* certificate_new(X509* x509);
 Certificate* certificate_copy(Certificate* cert);
 void certificate_free(Certificate* cert);
 
+void parse_x509_certificates(const STACK_OF(X509) * certs, CertificateArray* result);
+
 CertificateArray* parse_signer_chain(X509* signer_cert, STACK_OF(X509) * certs);
 int certificate_array_move(CertificateArray* dst, CertificateArray* src);
 int certificate_array_append(CertificateArray* dst, CertificateArray* src);

--- a/src/countersignature.c
+++ b/src/countersignature.c
@@ -457,6 +457,9 @@ CountersignatureImpl* ms_countersig_impl_new(const uint8_t* data, long size)
         result->funcs = &FUNC_ARRAY_NAME_FOR_IMPL(pkcs7);
         result->pkcs7 = p7;
         return result;
+    } else if (p7) {
+        PKCS7_free(p7);
+        return NULL;
     }
 
     d = data;

--- a/tests/integration/test_microsoft.cpp
+++ b/tests/integration/test_microsoft.cpp
@@ -118,7 +118,7 @@ TEST_F(MicrosoftSignatureTest, SignatureContent)
     // Test all certificates of first signature //
     ASSERT_TRUE(first_sig->certs);
     ASSERT_TRUE(first_sig->certs->certs);
-    ASSERT_EQ(first_sig->certs->count, 2);
+    ASSERT_EQ(first_sig->certs->count, 4);
 
     //**************************//
     // Check the 1. certificate //
@@ -147,6 +147,26 @@ TEST_F(MicrosoftSignatureTest, SignatureContent)
     unsigned char second_cert_sha1[20] = {0x77, 0xa1, 0x0e, 0xbf, 0x07, 0x54, 0x27,
                                           0x25, 0x21, 0x8c, 0xd8, 0x3a, 0x01, 0xb5,
                                           0x21, 0xc5, 0x7b, 0xc6, 0x7f, 0x73};
+    EXPECT_TRUE(std::memcmp(second_cert_sha1, cert->sha1.data, 20) == 0);
+
+    //**************************//
+    // Check the 3. certificate //
+    cert = first_sig->certs->certs[1];
+    ASSERT_TRUE(cert->sha1.data);
+    ASSERT_EQ(cert->sha1.len, 20);
+    unsigned char third_cert_sha1[20] = {0x9a, 0xb3, 0xfa, 0x0a, 0x1a, 0xdb, 0xcf,
+                                         0x46, 0xb1, 0xee, 0xce, 0x7b, 0x9f, 0x93,
+                                         0xe8, 0xa7, 0x75, 0x42, 0xf2, 0x0c};
+    EXPECT_TRUE(std::memcmp(second_cert_sha1, cert->sha1.data, 20) == 0);
+
+    //**************************//
+    // Check the 4. certificate //
+    cert = first_sig->certs->certs[1];
+    ASSERT_TRUE(cert->sha1.data);
+    ASSERT_EQ(cert->sha1.len, 20);
+    unsigned char fourth_cert_sha1[20] = {0x2a, 0xa7, 0x52, 0xfe, 0x64, 0xc4, 0x9a,
+                                          0xbe, 0x82, 0x91, 0x3c, 0x46, 0x35, 0x29,
+                                          0xcf, 0x10, 0xff, 0x2f, 0x04, 0xee};
     EXPECT_TRUE(std::memcmp(second_cert_sha1, cert->sha1.data, 20) == 0);
 
     //**************************//
@@ -226,15 +246,22 @@ TEST_F(MicrosoftSignatureTest, SignatureContent)
 
     EXPECT_EQ(cert->version, 2);
     EXPECT_STREQ(
-        cert->subject, "/C=US/ST=Washington/L=Redmond/O=Microsoft Corporation/CN=Microsoft Time-Stamp PCA 2010");
+        cert->subject,
+        "/C=US/ST=Washington/L=Redmond/O=Microsoft Corporation/CN=Microsoft Time-Stamp PCA 2010");
     EXPECT_STREQ(
         cert->issuer,
-        "/C=US/ST=Washington/L=Redmond/O=Microsoft Corporation/CN=Microsoft Root Certificate Authority 2010");
+        "/C=US/ST=Washington/L=Redmond/O=Microsoft Corporation/CN=Microsoft Root Certificate "
+        "Authority 2010");
     EXPECT_EQ(cert->not_after, 1751406415);
     EXPECT_EQ(cert->not_before, 1278020215);
     EXPECT_STREQ(
         cert->key,
-        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqR0NvHcRijog7PwTl/X6f2mUa3RUENWlCgCChfvtfGhLLF/Fw+Vhwna3PmYrW/AVUycEMR9BGxqVHc4JE458YTBZsTBED/FgiIRUQwzXTbg4CLNC3ZOs1nMwVyaCo0UN0Or1R4HNvyRgMlhgRvJYR4YyhB50YWeRX4FUsc+TTJLBxKZd0WETbijGGvmGgLvfYfxGwScdJGcSchohiq9LZIlQYrFd/XcfPfBXday9ikJNQFHRD5wGPmd/9WbAA5ZEfu/QS/1u5ZrKsajyeioKMfDaTgaRtogINeh4HLDpmc085y9Euqf03GS9pAHBIAmTeM38vMDJRF1eFpwBBU8iTQIDAQAB");
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqR0NvHcRijog7PwTl/"
+        "X6f2mUa3RUENWlCgCChfvtfGhLLF/Fw+Vhwna3PmYrW/AVUycEMR9BGxqVHc4JE458YTBZsTBED/"
+        "FgiIRUQwzXTbg4CLNC3ZOs1nMwVyaCo0UN0Or1R4HNvyRgMlhgRvJYR4YyhB50YWeRX4FUsc+"
+        "TTJLBxKZd0WETbijGGvmGgLvfYfxGwScdJGcSchohiq9LZIlQYrFd/XcfPfBXday9ikJNQFHRD5wGPmd/"
+        "9WbAA5ZEfu/QS/"
+        "1u5ZrKsajyeioKMfDaTgaRtogINeh4HLDpmc085y9Euqf03GS9pAHBIAmTeM38vMDJRF1eFpwBBU8iTQIDAQAB");
     EXPECT_STREQ(cert->serial, "61:09:81:2a:00:00:00:00:00:02");
     EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
     EXPECT_STREQ(cert->key_alg, "rsaEncryption");

--- a/tests/integration/test_non_microsoft.cpp
+++ b/tests/integration/test_non_microsoft.cpp
@@ -480,48 +480,6 @@ TEST_F(SignatureTest, SecondSignatureContent)
     cert = second_sig->certs->certs[1];
     ASSERT_TRUE(cert->sha1.data);
     ASSERT_EQ(cert->sha1.len, 20);
-    unsigned char second_cert_sha1[20] = {0x6f, 0xc9, 0xed, 0xb5, 0xe0, 0x0a, 0xb6,
-                                          0x41, 0x51, 0xc1, 0xcd, 0xfc, 0xac, 0x74,
-                                          0xad, 0x2c, 0x7b, 0x7e, 0x3b, 0xe4};
-    EXPECT_TRUE(std::memcmp(second_cert_sha1, cert->sha1.data, 20) == 0);
-
-    ASSERT_TRUE(cert->sha256.data);
-    ASSERT_EQ(cert->sha256.len, 32);
-    unsigned char second_cert_sha256[32] = {0xf3, 0x51, 0x6d, 0xdc, 0xc8, 0xaf, 0xc8, 0x08,
-                                            0x78, 0x8b, 0xd8, 0xb0, 0xe8, 0x40, 0xbd, 0xa2,
-                                            0xb5, 0xe2, 0x3c, 0x62, 0x44, 0x25, 0x2c, 0xa3,
-                                            0x00, 0x0b, 0xb6, 0xc8, 0x71, 0x70, 0x40, 0x2a};
-    EXPECT_TRUE(std::memcmp(second_cert_sha256, cert->sha256.data, 32) == 0);
-
-    EXPECT_EQ(cert->version, 2);
-    EXPECT_STREQ(
-        cert->subject,
-        "/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec SHA256 TimeStamping "
-        "CA");
-    EXPECT_STREQ(
-        cert->issuer,
-        "/C=US/O=VeriSign, Inc./OU=VeriSign Trust Network/OU=(c) 2008 VeriSign, Inc. - For "
-        "authorized use only/CN=VeriSign Universal Root Certification Authority");
-    EXPECT_EQ(cert->not_after, 1925942399);
-    EXPECT_EQ(cert->not_before, 1452556800);
-    EXPECT_STREQ(
-        cert->key,
-        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1mdWVVPnYxyXRqBoutV87ABrTxxrDKPBWuGmicAMpdqTc"
-        "lkFEspu8LZKbku7GOz4c8/C1aQ+GIbfuumB+Lef15tQDjUkQbnQXx5HMvLrRu/2JWR8/"
-        "DubPitljkuf8EnuHg5xYSl7e2vh47Ojcdt6tKYtTofHjmdw/SaqPSE4cTRfHHGBim0P+SDDSbDewg+TfkKtzNJ/"
-        "8o71PWym0vhiJka9cDpMxTW38eA25Hu/"
-        "rySV3J39M2ozP4J9ZM3vpWIasXc9LFL1M7oCZFftYR5NYp4rBkyjyPBMkEbWQ6pPrHM+"
-        "dYr77fY5NUdbRE6kvaTyZzjSO67Uw7UNpeGeMWhNwIDAQAB");
-    EXPECT_STREQ(cert->serial, "7b:05:b1:d4:49:68:51:44:f7:c9:89:d2:9c:19:9d:12");
-    EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
-    EXPECT_STREQ(cert->sig_alg_oid, "1.2.840.113549.1.1.11");
-    EXPECT_STREQ(cert->key_alg, "rsaEncryption");
-
-    //**************************//
-    // Check the 3. certificate //
-    cert = second_sig->certs->certs[2];
-    ASSERT_TRUE(cert->sha1.data);
-    ASSERT_EQ(cert->sha1.len, 20);
     unsigned char third_cert_sha1[20] = {0xa9, 0xa4, 0x12, 0x10, 0x63, 0xd7, 0x1d,
                                          0x48, 0xe8, 0x52, 0x9a, 0x46, 0x81, 0xde,
                                          0x80, 0x3e, 0x3e, 0x79, 0x54, 0xb0};
@@ -555,6 +513,48 @@ TEST_F(SignatureTest, SecondSignatureContent)
         "SrcidmXs7DbylpWBJiz9u5iqATjTryVAmwlT8ClXhVhe6oVIQSGH5d600yaye0BTWHmOUjEGTZQDRcTOPAPstwDyOi"
         "LFtG/l77CKmwIDAQAB");
     EXPECT_STREQ(cert->serial, "7b:d4:e5:af:ba:cc:07:3f:a1:01:23:04:22:41:4d:12");
+    EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
+    EXPECT_STREQ(cert->sig_alg_oid, "1.2.840.113549.1.1.11");
+    EXPECT_STREQ(cert->key_alg, "rsaEncryption");
+
+    //**************************//
+    // Check the 3. certificate //
+    cert = second_sig->certs->certs[2];
+    ASSERT_TRUE(cert->sha1.data);
+    ASSERT_EQ(cert->sha1.len, 20);
+    unsigned char second_cert_sha1[20] = {0x6f, 0xc9, 0xed, 0xb5, 0xe0, 0x0a, 0xb6,
+                                          0x41, 0x51, 0xc1, 0xcd, 0xfc, 0xac, 0x74,
+                                          0xad, 0x2c, 0x7b, 0x7e, 0x3b, 0xe4};
+    EXPECT_TRUE(std::memcmp(second_cert_sha1, cert->sha1.data, 20) == 0);
+
+    ASSERT_TRUE(cert->sha256.data);
+    ASSERT_EQ(cert->sha256.len, 32);
+    unsigned char second_cert_sha256[32] = {0xf3, 0x51, 0x6d, 0xdc, 0xc8, 0xaf, 0xc8, 0x08,
+                                            0x78, 0x8b, 0xd8, 0xb0, 0xe8, 0x40, 0xbd, 0xa2,
+                                            0xb5, 0xe2, 0x3c, 0x62, 0x44, 0x25, 0x2c, 0xa3,
+                                            0x00, 0x0b, 0xb6, 0xc8, 0x71, 0x70, 0x40, 0x2a};
+    EXPECT_TRUE(std::memcmp(second_cert_sha256, cert->sha256.data, 32) == 0);
+
+    EXPECT_EQ(cert->version, 2);
+    EXPECT_STREQ(
+        cert->subject,
+        "/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec SHA256 TimeStamping "
+        "CA");
+    EXPECT_STREQ(
+        cert->issuer,
+        "/C=US/O=VeriSign, Inc./OU=VeriSign Trust Network/OU=(c) 2008 VeriSign, Inc. - For "
+        "authorized use only/CN=VeriSign Universal Root Certification Authority");
+    EXPECT_EQ(cert->not_after, 1925942399);
+    EXPECT_EQ(cert->not_before, 1452556800);
+    EXPECT_STREQ(
+        cert->key,
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1mdWVVPnYxyXRqBoutV87ABrTxxrDKPBWuGmicAMpdqTc"
+        "lkFEspu8LZKbku7GOz4c8/C1aQ+GIbfuumB+Lef15tQDjUkQbnQXx5HMvLrRu/2JWR8/"
+        "DubPitljkuf8EnuHg5xYSl7e2vh47Ojcdt6tKYtTofHjmdw/SaqPSE4cTRfHHGBim0P+SDDSbDewg+TfkKtzNJ/"
+        "8o71PWym0vhiJka9cDpMxTW38eA25Hu/"
+        "rySV3J39M2ozP4J9ZM3vpWIasXc9LFL1M7oCZFftYR5NYp4rBkyjyPBMkEbWQ6pPrHM+"
+        "dYr77fY5NUdbRE6kvaTyZzjSO67Uw7UNpeGeMWhNwIDAQAB");
+    EXPECT_STREQ(cert->serial, "7b:05:b1:d4:49:68:51:44:f7:c9:89:d2:9c:19:9d:12");
     EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
     EXPECT_STREQ(cert->sig_alg_oid, "1.2.840.113549.1.1.11");
     EXPECT_STREQ(cert->key_alg, "rsaEncryption");

--- a/tests/integration/test_non_microsoft.cpp
+++ b/tests/integration/test_non_microsoft.cpp
@@ -480,48 +480,6 @@ TEST_F(SignatureTest, SecondSignatureContent)
     cert = second_sig->certs->certs[1];
     ASSERT_TRUE(cert->sha1.data);
     ASSERT_EQ(cert->sha1.len, 20);
-    unsigned char third_cert_sha1[20] = {0xa9, 0xa4, 0x12, 0x10, 0x63, 0xd7, 0x1d,
-                                         0x48, 0xe8, 0x52, 0x9a, 0x46, 0x81, 0xde,
-                                         0x80, 0x3e, 0x3e, 0x79, 0x54, 0xb0};
-    EXPECT_TRUE(std::memcmp(third_cert_sha1, cert->sha1.data, 20) == 0);
-
-    ASSERT_TRUE(cert->sha256.data);
-    ASSERT_EQ(cert->sha256.len, 32);
-    unsigned char third_cert_sha256[32] = {0xc4, 0x74, 0xce, 0x76, 0x00, 0x7d, 0x02, 0x39,
-                                           0x4e, 0x0d, 0xa5, 0xe4, 0xde, 0x7c, 0x14, 0xc6,
-                                           0x80, 0xf9, 0xe2, 0x82, 0x01, 0x3c, 0xfe, 0xf6,
-                                           0x53, 0xef, 0x5d, 0xb7, 0x1f, 0xdf, 0x61, 0xf8};
-    EXPECT_TRUE(std::memcmp(third_cert_sha256, cert->sha256.data, 32) == 0);
-
-    EXPECT_EQ(cert->version, 2);
-    EXPECT_STREQ(
-        cert->subject,
-        "/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec SHA256 TimeStamping "
-        "Signer - G3");
-    EXPECT_STREQ(
-        cert->issuer,
-        "/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec SHA256 TimeStamping "
-        "CA");
-    EXPECT_EQ(cert->not_after, 1868918399);
-    EXPECT_EQ(cert->not_before, 1513987200);
-    EXPECT_STREQ(
-        cert->key,
-        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArw6Kqvjcv2l7VBdxRwm9jTyB+"
-        "HQVd2eQnP3eTgKeS3b25TY+ZdUkIG0w+d0dg+k/"
-        "J0ozTm0WiuSNQI0iqr6nCxvSB7Y8tRokKPgbclE9yAmIJgg6+fpDI3VHcAyzX1uPCB1ySFdlTa8CPED39N0yOJM/"
-        "5Sym81kjy4DeE035EMmqChhsVWFX0fECLMS1q/JsI9KfDQ8ZbK2FYmn9ToXBilIxq1vYyXRS41dsIr9Vf2/KBqs/"
-        "SrcidmXs7DbylpWBJiz9u5iqATjTryVAmwlT8ClXhVhe6oVIQSGH5d600yaye0BTWHmOUjEGTZQDRcTOPAPstwDyOi"
-        "LFtG/l77CKmwIDAQAB");
-    EXPECT_STREQ(cert->serial, "7b:d4:e5:af:ba:cc:07:3f:a1:01:23:04:22:41:4d:12");
-    EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
-    EXPECT_STREQ(cert->sig_alg_oid, "1.2.840.113549.1.1.11");
-    EXPECT_STREQ(cert->key_alg, "rsaEncryption");
-
-    //**************************//
-    // Check the 3. certificate //
-    cert = second_sig->certs->certs[2];
-    ASSERT_TRUE(cert->sha1.data);
-    ASSERT_EQ(cert->sha1.len, 20);
     unsigned char second_cert_sha1[20] = {0x6f, 0xc9, 0xed, 0xb5, 0xe0, 0x0a, 0xb6,
                                           0x41, 0x51, 0xc1, 0xcd, 0xfc, 0xac, 0x74,
                                           0xad, 0x2c, 0x7b, 0x7e, 0x3b, 0xe4};
@@ -555,6 +513,48 @@ TEST_F(SignatureTest, SecondSignatureContent)
         "rySV3J39M2ozP4J9ZM3vpWIasXc9LFL1M7oCZFftYR5NYp4rBkyjyPBMkEbWQ6pPrHM+"
         "dYr77fY5NUdbRE6kvaTyZzjSO67Uw7UNpeGeMWhNwIDAQAB");
     EXPECT_STREQ(cert->serial, "7b:05:b1:d4:49:68:51:44:f7:c9:89:d2:9c:19:9d:12");
+    EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
+    EXPECT_STREQ(cert->sig_alg_oid, "1.2.840.113549.1.1.11");
+    EXPECT_STREQ(cert->key_alg, "rsaEncryption");
+
+    //**************************//
+    // Check the 3. certificate //
+    cert = second_sig->certs->certs[2];
+    ASSERT_TRUE(cert->sha1.data);
+    ASSERT_EQ(cert->sha1.len, 20);
+    unsigned char third_cert_sha1[20] = {0xa9, 0xa4, 0x12, 0x10, 0x63, 0xd7, 0x1d,
+                                         0x48, 0xe8, 0x52, 0x9a, 0x46, 0x81, 0xde,
+                                         0x80, 0x3e, 0x3e, 0x79, 0x54, 0xb0};
+    EXPECT_TRUE(std::memcmp(third_cert_sha1, cert->sha1.data, 20) == 0);
+
+    ASSERT_TRUE(cert->sha256.data);
+    ASSERT_EQ(cert->sha256.len, 32);
+    unsigned char third_cert_sha256[32] = {0xc4, 0x74, 0xce, 0x76, 0x00, 0x7d, 0x02, 0x39,
+                                           0x4e, 0x0d, 0xa5, 0xe4, 0xde, 0x7c, 0x14, 0xc6,
+                                           0x80, 0xf9, 0xe2, 0x82, 0x01, 0x3c, 0xfe, 0xf6,
+                                           0x53, 0xef, 0x5d, 0xb7, 0x1f, 0xdf, 0x61, 0xf8};
+    EXPECT_TRUE(std::memcmp(third_cert_sha256, cert->sha256.data, 32) == 0);
+
+    EXPECT_EQ(cert->version, 2);
+    EXPECT_STREQ(
+        cert->subject,
+        "/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec SHA256 TimeStamping "
+        "Signer - G3");
+    EXPECT_STREQ(
+        cert->issuer,
+        "/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec SHA256 TimeStamping "
+        "CA");
+    EXPECT_EQ(cert->not_after, 1868918399);
+    EXPECT_EQ(cert->not_before, 1513987200);
+    EXPECT_STREQ(
+        cert->key,
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArw6Kqvjcv2l7VBdxRwm9jTyB+"
+        "HQVd2eQnP3eTgKeS3b25TY+ZdUkIG0w+d0dg+k/"
+        "J0ozTm0WiuSNQI0iqr6nCxvSB7Y8tRokKPgbclE9yAmIJgg6+fpDI3VHcAyzX1uPCB1ySFdlTa8CPED39N0yOJM/"
+        "5Sym81kjy4DeE035EMmqChhsVWFX0fECLMS1q/JsI9KfDQ8ZbK2FYmn9ToXBilIxq1vYyXRS41dsIr9Vf2/KBqs/"
+        "SrcidmXs7DbylpWBJiz9u5iqATjTryVAmwlT8ClXhVhe6oVIQSGH5d600yaye0BTWHmOUjEGTZQDRcTOPAPstwDyOi"
+        "LFtG/l77CKmwIDAQAB");
+    EXPECT_STREQ(cert->serial, "7b:d4:e5:af:ba:cc:07:3f:a1:01:23:04:22:41:4d:12");
     EXPECT_STREQ(cert->sig_alg, "sha256WithRSAEncryption");
     EXPECT_STREQ(cert->sig_alg_oid, "1.2.840.113549.1.1.11");
     EXPECT_STREQ(cert->key_alg, "rsaEncryption");


### PR DESCRIPTION
Code was missing copying over MS signatures certificates when it is using a CMS format, this is fixed in the PR.

I've realized why it wasn't written in this way before, I didn't want to write all the deep copy functions, however now that we have CMS aswell I can't avoid it anymore.

Also closes https://github.com/avast/authenticode-parser/issues/19

Also found and fixed memory leak when parsing counter signature